### PR TITLE
Fix PostgreSQL provider in schema.prisma when Postgres is selected

### DIFF
--- a/packages/codegen-cli/src/scripts/setup-database.ts
+++ b/packages/codegen-cli/src/scripts/setup-database.ts
@@ -80,7 +80,7 @@ async function setupWithPrisma(
     if (database === "Postgres") {
       await execa(
         "npx",
-        ["prisma", "init", "--datasource-provider", "mongodb"],
+        ["prisma", "init", "--datasource-provider", "postgresql"],
         {
           cwd: rootDir,
         },


### PR DESCRIPTION
### Issue
When a user selects PostgreSQL as their database during Next.js project creation, the schema.prisma file was incorrectly configured with MongoDB as the provider instead of PostgreSQL.

### Fix
Changed the Prisma initialization parameter in `setupWithPrisma` function from `mongodb` to `postgresql` to ensure the database provider is correctly set in the schema.prisma file.


Issue: [#22](https://github.com/Leo5661/codegen/issues/22)
